### PR TITLE
Added support for files which make use of the GFF3 FASTA directive

### DIFF
--- a/applications/bed/conversion/src/gff2bed.py
+++ b/applications/bed/conversion/src/gff2bed.py
@@ -151,7 +151,7 @@ def checkInstallation(rv):
 def consumeGFF(from_stream, to_stream, params):
     while True:
         gff_line = from_stream.readline()
-        if not gff_line:
+        if not gff_line or gff_line.startswith("##FASTA"):
             from_stream.close()
             to_stream.close()
             break


### PR DESCRIPTION
This PR allows gff2bed.py to recognize [GFF3 ##FASTA](http://www.sequenceontology.org/gff3.shtml) sections and stop processing without emitting any error messages.

Currently, once the script encounters the first entry in the ##FASTA section it fails to parse the line and emits and error message ("Error: Could not import GFF data...")

Example gff file to reproduce the issue: [TriTrypDB-7.0_LmajorFriedlin.gff](http://tritrypdb.org/common/downloads/release-7.0/LmajorFriedlin/gff/data/TriTrypDB-7.0_LmajorFriedlin.gff)
