### PR TITLE
made gff2bed work as stand-alone if --do-not-sort specified

### DIFF
--- a/applications/bed/conversion/src/gff2bed.py
+++ b/applications/bed/conversion/src/gff2bed.py
@@ -363,14 +363,14 @@ def main(*args):
         printUsage("stderr")
         return os.EX_NOINPUT
 
-    try:
-        if which('sort-bed') is None:
-            raise IOError("The sort-bed binary could not be found in your user PATH -- please locate and install this binary")
-    except IOError, msg:
-        sys.stderr.write( "[%s] - %s\n" % (sys.argv[0], msg) )
-        return os.EX_OSFILE
 
     if params.sortOutput:
+        try:
+            if which('sort-bed') is None:
+                raise IOError("The sort-bed binary could not be found in your user PATH -- please locate and install this binary")
+        except IOError, msg:
+            sys.stderr.write( "[%s] - %s\n" % (sys.argv[0], msg) )
+            return os.EX_OSFILE
         if params.sortTmpdirSet:
             sortbed_process = subprocess.Popen(['sort-bed', '--max-mem', params.maxMem, '--tmpdir', params.sortTmpdir, '-'], stdin=subprocess.PIPE, stdout=sys.stdout)
         else:


### PR DESCRIPTION
Your gff2bed script is very useful, but as a user I just want to be able to download and use this script without the rest of your whole package, and I don't care about sorting. I moved the lines that check to see whether sort-bed is installed so that you don't get an error about not having sort-bed installed when the script isn't even going to call it. Hope this helps!
