### PR TITLE
Add a basic docker build based on debian:jessie.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+docs
+LICENSE
+packaging
+README.md
+.travis.yml
+.gitignore
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,5 @@
 .git
 docs
-LICENSE
-packaging
-README.md
 .travis.yml
 .gitignore
 .dockerignore

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ ifndef NEW_VER
 endif
 ifeq ($(KERNEL), Darwin)
 	sed -i "" -e "s/"$$OLD_VER"/"$$NEW_VER"/g" README.md
+	sed -i "" -e "s/"$$OLD_VER"/"$$NEW_VER"/g" packaging/rpm/bedops.spec
 	sed -i "" -e "s/"$$OLD_VER"/"$$NEW_VER"/g" interfaces/general-headers/suite/BEDOPS.Version.hpp
 	sed -i "" -e "s/"$$OLD_VER"/"$$NEW_VER"/g" packaging/os_x/BEDOPS.pkgproj
 	sed -i "" -e "s/"$$OLD_VER"/"$$NEW_VER"/g" docs/index.rst
@@ -145,6 +146,7 @@ ifeq ($(KERNEL), Darwin)
 	find docs/content -type f -exec sed -i "" -e "s/"$$OLD_VER"/"$$NEW_VER"/g" {} +
 else
 	sed -i "s/"$$OLD_VER"/"$$NEW_VER"/g" README.md
+	sed -i "s/"$$OLD_VER"/"$$NEW_VER"/g" packaging/rpm/bedops.spec
 	sed -i "s/"$$OLD_VER"/"$$NEW_VER"/g" interfaces/general-headers/suite/BEDOPS.Version.hpp
 	sed -i "s/"$$OLD_VER"/"$$NEW_VER"/g" packaging/os_x/BEDOPS.pkgproj
 	sed -i "s/"$$OLD_VER"/"$$NEW_VER"/g" docs/index.rst
@@ -154,3 +156,6 @@ endif
 
 docker: packaging/docker/Dockerfile
 	docker build -t bedops -f packaging/docker/Dockerfile  .
+
+rpm: packaging/rpm/Dockerfile
+	docker build -t bedops:rpm -f packaging/rpm/Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -151,3 +151,6 @@ else
 	sed -i "s/"$$OLD_VER"/"$$NEW_VER"/g" docs/conf.py
 	find docs/content -type f -exec sed -i "s/"$$OLD_VER"/"$$NEW_VER"/g" {} +
 endif
+
+docker: packaging/docker/Dockerfile
+	docker build -t bedops -f packaging/docker/Dockerfile  .

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:jessie
+
+# install the necessary tooling
+RUN apt-get update && apt-get install -y \
+     bzip2 \
+     g++ \
+     git \
+     make \
+     tcsh
+
+# copy the source context into the local image & build/install
+#  note: make sure .dockerignore is up to date
+RUN mkdir /bedops
+ADD . /bedops
+RUN cd /bedops && make -j`nproc` && make install && cp bin/* /usr/local/bin
+
+# clean up to save space
+RUN apt-get -y autoremove g++ git make bzip2
+RUN apt-get -y clean all
+RUN rm -rf /var/lib/apt/* 
+RUN rm -rf /bedops
+
+# note: default entrypoint is sh -c

--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:7
+
+# install the necessary tooling
+RUN yum -y install tar \ 
+                   make \
+                   gcc \
+                   gcc-c++ \
+                   rpm-build \
+                   glibc-static \
+                   libstdc++-static
+
+# copy the source context into the local image & build/install
+#  note: make sure .dockerignore is up to date
+RUN mkdir /bedops-2.4.14
+ADD . /bedops-2.4.14
+RUN tar zcf /bedops-2.4.14.tar.gz bedops-2.4.14
+RUN rm -rf /bedops-2.4.14
+RUN rpmbuild -ta bedops-2.4.14.tar.gz
+RUN rm /bedops-2.4.14.tar.gz
+

--- a/packaging/rpm/bedops.spec
+++ b/packaging/rpm/bedops.spec
@@ -1,0 +1,28 @@
+Name:           bedops
+Version:        2.4.14
+Release:        1
+Summary:        A suite of tools to address common questions raised in genomic studies.
+Group:          Applications/Productivity
+License:        GPLv2
+URL:            http://bedops.readthedocs.org/
+Source0:        %{name}-%{version}.tar.gz
+Requires:       tcsh
+BuildRequires:  glibc-static
+BuildRequires:  libstdc++-static
+
+%description
+BEDOPS is a suite of tools to address common questions raised in genomic studies — mostly with regard to overlap and proximity relationships between data sets. It aims to be scalable and flexible, facilitating the efficient and accurate analysis and management of large-scale genomic data.
+
+%prep
+%autosetup
+
+%build
+make %{?_smp_mflags}
+%install
+make install BINDIR=%{buildroot}%_bindir
+%clean
+make clean
+
+%files
+%{_bindir}/*
+%doc LICENSE README.md


### PR DESCRIPTION
Here's a first go at integrating docker image creation into the makefile.  To use this, you would just run "make docker" then "docker run -i -t bedops" which will drop you into a shell from which you can execute the commands.