### PR TITLE
Darwin makefile upgrade

### DIFF
--- a/applications/bed/bedextract/src/Makefile.darwin
+++ b/applications/bed/bedextract/src/Makefile.darwin
@@ -21,46 +21,62 @@ LOCALBZIP2LIBDIR     = ${LOCALBZIP2DIR}
 LOCALBZIP2LIB        = ${LOCALBZIP2LIBDIR}/${LIBBZIP2}
 LOCALBZIP2INCDIR     = ${LOCALBZIP2DIR}
 LOCALZLIBDIR         = ${PARTY3}/darwin_intel_${ARCH}/zlib
-LOCALZLIBLIBDIR      = ${LOCALZLIBDIR}
-LOCALZLIBLIB         = ${LOCALZLIBLIBDIR}/${LIBZLIB}
+LOCALZLIBLIB         = ${LOCALZLIBDIR}/${LIBZLIB}
 LOCALZLIBINCDIR      = ${LOCALZLIBDIR}
+OBJDIR               = objects_$(ARCH)
 INCLUDES             = -iquote$(HEAD) -I${LOCALJANSSONINCDIR} -I${LOCALBZIP2INCDIR} -I${LOCALZLIBINCDIR}
-LIBLOCATION          = -L${LOCALJANSSONLIBDIR} -L${LOCALBZIP2LIBDIR} -L${LOCALZLIBLIBDIR}
+LIBLOCATION          = -L${LOCALJANSSONLIBDIR} -L${LOCALBZIP2LIBDIR} -L${LOCALZLIBDIR}
 LIBRARIES            = ${LOCALJANSSONLIB} ${LOCALBZIP2LIB} ${LOCALZLIBLIB}
 STDFLAGS             = -Wall -pedantic -std=c++11 -stdlib=libc++
 BLDFLAGS             = -O3 ${STDFLAGS}
 
+DEPENDENCIES         = $(addprefix $(OBJDIR)/,   \
+                         NaN.o                   \
+												 starchBase64Coding.o    \
+												 starchConstants.o       \
+												 starchFileHelpers.o     \
+												 starchHelpers.o         \
+												 starchMetadataHelpers.o \
+												 starchSha1Digest.o      \
+												 unstarchHelpers.o       )
 
-FLAGS                = $(BLDFLAGS) $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+FLAGS                = $(BLDFLAGS) $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
-DFLAGS               = -g -O0 ${STDFLAGS} $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+DFLAGS               = -g -O0 ${STDFLAGS} $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
-GPROFFLAGS           = -O -pg ${STDFLAGS} $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+GPROFFLAGS           = -O -pg ${STDFLAGS} $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
 SOURCE1              = ExtractRows.cpp
 BINDIR               = ../bin
 PROG                 = bedextract
 
-build: dependencies
-	$(CXX) -o $(BINDIR)/$(PROG)_$(ARCH) $(FLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+MACFLAGS             = -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH)
 
-build_debug: dependencies
-	$(CXX) -o $(BINDIR)/debug.$(PROG)_$(ARCH) $(DFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+build: $(BINDIR)/$(PROG)_$(ARCH) $(DEPENDENCIES)
 
-build_gprof: dependencies
-	$(CXX) -o $(BINDIR)/gprof.$(PROG)_$(ARCH) $(GPROFFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+build_debug: $(BINDIR)/debug.$(PROG)_$(ARCH)
 
-dependencies:
-	rm -rf $(OBJDIR)
-	mkdir -p $(OBJDIR)
-	$(CXX) -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB1)/NaN.cpp -o $(OBJDIR)/NaN.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchConstants.c -o $(OBJDIR)/starchConstants.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchFileHelpers.c -o $(OBJDIR)/starchFileHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchHelpers.c -o $(OBJDIR)/starchHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchMetadataHelpers.c -o $(OBJDIR)/starchMetadataHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/unstarchHelpers.c -o $(OBJDIR)/unstarchHelpers.o ${INCLUDES}
-	${CXX} -x c++ -c ${BLDFLAGS} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIB3}/starchSha1Digest.c -o  ${OBJDIR}/starchSha1Digest.o ${INCLUDES}
-	${CXX} -x c++ -c ${BLDFLAGS} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIB3}/starchBase64Coding.c -o  ${OBJDIR}/starchBase64Coding.o ${INCLUDES}
+build_gprof: $(BINDIR)/gprof.$(PROG)_$(ARCH)
+
+dependencies: $(DEPENDENCIES)
+
+# Binaries
+$(BINDIR)/$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(FLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+$(BINDIR)/debug.$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(DFLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+$(BINDIR)/gprof.$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(GPROFFLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+# Object files
+$(OBJDIR)/%.o : $(LIB1)/%.cpp
+	mkdir -p $(OBJDIR) && $(CXX) -c $(BLDFLAGS) $(MACFLAGS) $< -o $@ ${INCLUDES}
+
+$(OBJDIR)/%.o : $(LIB3)/%.c
+	$(CXX) -x c++ -c $(BLDFLAGS) $(MACFLAGS) $< -o $@ ${INCLUDES}
+
 
 clean:
 	rm -rf $(OBJDIR)

--- a/applications/bed/bedmap/src/Makefile.darwin
+++ b/applications/bed/bedmap/src/Makefile.darwin
@@ -30,36 +30,53 @@ LIBRARIES            = ${LOCALJANSSONLIB} ${LOCALBZIP2LIB} ${LOCALZLIBLIB}
 STDFLAGS             = -Wall -pedantic -std=c++11 -stdlib=libc++
 BLDFLAGS             = -O3 ${STDFLAGS}
 
-FLAGS                = $(BLDFLAGS) $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+DEPENDENCIES         = $(addprefix $(OBJDIR)/,   \
+                         NaN.o                   \
+												 starchBase64Coding.o    \
+												 starchConstants.o       \
+												 starchFileHelpers.o     \
+												 starchHelpers.o         \
+												 starchMetadataHelpers.o \
+												 starchSha1Digest.o      \
+												 unstarchHelpers.o       )
 
-DFLAGS               = -g -O0 -DDEBUG=1 ${STDFLAGS} $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+FLAGS                = $(BLDFLAGS) $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
-GPROFFLAGS           = -O -pg ${STDFLAGS} $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+DFLAGS               = -g -O0 -DDEBUG=1 ${STDFLAGS} $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
+
+GPROFFLAGS           = -O -pg ${STDFLAGS} $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
 SOURCE1              = Bedmap.cpp
 BINDIR               = ../bin
 PROG                 = bedmap
 
-build: dependencies
-	$(CXX) -o $(BINDIR)/$(PROG)_$(ARCH) $(FLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+MACFLAGS             = -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH)
 
-build_debug: dependencies
-	$(CXX) -o $(BINDIR)/debug.$(PROG)_$(ARCH) $(DFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+build: $(BINDIR)/$(PROG)_$(ARCH) $(DEPENDENCIES)
 
-build_gprof: dependencies
-	$(CXX) -o $(BINDIR)/gprof.$(PROG)_$(ARCH) $(GPROFFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+build_debug: $(BINDIR)/debug.$(PROG)_$(ARCH)
 
-dependencies:
-	rm -rf $(OBJDIR)
-	mkdir $(OBJDIR)
-	$(CXX) -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB1)/NaN.cpp -o $(OBJDIR)/NaN.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchConstants.c -o $(OBJDIR)/starchConstants.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchFileHelpers.c -o $(OBJDIR)/starchFileHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchHelpers.c -o $(OBJDIR)/starchHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchMetadataHelpers.c -o $(OBJDIR)/starchMetadataHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/unstarchHelpers.c -o $(OBJDIR)/unstarchHelpers.o ${INCLUDES}
-	${CXX} -x c++ -c ${BLDFLAGS} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIB3}/starchSha1Digest.c -o  ${OBJDIR}/starchSha1Digest.o ${INCLUDES}
-	${CXX} -x c++ -c ${BLDFLAGS} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIB3}/starchBase64Coding.c -o  ${OBJDIR}/starchBase64Coding.o ${INCLUDES}
+build_gprof: $(BINDIR)/gprof.$(PROG)_$(ARCH)
+
+dependencies: $(DEPENDENCIES)
+
+# Binaries
+$(BINDIR)/$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(FLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+$(BINDIR)/debug.$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(DFLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+$(BINDIR)/gprof.$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(GPROFFLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+# Object files
+$(OBJDIR)/%.o : $(LIB1)/%.cpp
+	mkdir -p $(OBJDIR) && $(CXX) -c $(BLDFLAGS) $(MACFLAGS) $< -o $@ ${INCLUDES}
+
+$(OBJDIR)/%.o : $(LIB3)/%.c
+	$(CXX) -x c++ -c $(BLDFLAGS) $(MACFLAGS) $< -o $@ ${INCLUDES}
+
 
 clean:
 	rm -rf $(OBJDIR)

--- a/applications/bed/bedops/src/Makefile.darwin
+++ b/applications/bed/bedops/src/Makefile.darwin
@@ -8,6 +8,7 @@ LIB2                 = $(MAIN)/interfaces/src/utility
 LIB3                 = $(MAIN)/interfaces/src/data/starch
 THISDIR              = ${shell pwd}
 PARTY3               = ${THISDIR}/$(MAIN)/third-party
+OBJDIR               = objects_$(ARCH)
 LIBJANSSON           = libjansson.a
 LIBBZIP2             = libbz2.a
 LIBZLIB              = libz.a
@@ -29,36 +30,52 @@ LIBRARIES            = ${LOCALJANSSONLIB} ${LOCALBZIP2LIB} ${LOCALZLIBLIB}
 STDFLAGS             = -Wall -pedantic -std=c++11 -stdlib=libc++
 BLDFLAGS             = -O3 ${STDFLAGS}
 
-FLAGS                = $(BLDFLAGS) $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+DEPENDENCIES         = $(addprefix $(OBJDIR)/,   \
+                         NaN.o                   \
+												 starchBase64Coding.o    \
+												 starchConstants.o       \
+												 starchFileHelpers.o     \
+												 starchHelpers.o         \
+												 starchMetadataHelpers.o \
+												 starchSha1Digest.o      \
+												 unstarchHelpers.o       )
 
-DFLAGS               = -g -O0 -DDEBUG_VERBOSE=1 ${STDFLAGS} $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+FLAGS                = $(BLDFLAGS) $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
-GPROFFLAGS           = -O -pg ${STDFLAGS} $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+DFLAGS               = -g -O0 -DDEBUG_VERBOSE=1 ${STDFLAGS} $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
+
+GPROFFLAGS           = -O -pg ${STDFLAGS} $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
 SOURCE1              = Bedops.cpp
 BINDIR               = ../bin
 PROG                 = bedops
 
-build: dependencies
-	$(CXX) -o $(BINDIR)/$(PROG)_$(ARCH) $(FLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+MACFLAGS             = -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH)
 
-build_debug: dependencies
-	$(CXX) -o $(BINDIR)/debug.$(PROG)_$(ARCH) $(DFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+build: $(BINDIR)/$(PROG)_$(ARCH) $(DEPENDENCIES)
 
-build_gprof: dependencies
-	$(CXX) -o $(BINDIR)/gprof.$(PROG)_$(ARCH) $(FLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+build_debug: $(BINDIR)/debug.$(PROG)_$(ARCH)
 
-dependencies:
-	rm -rf $(OBJDIR)
-	mkdir -p $(OBJDIR)
-	$(CXX) -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB1)/NaN.cpp -o $(OBJDIR)/NaN.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchConstants.c -o $(OBJDIR)/starchConstants.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchFileHelpers.c -o $(OBJDIR)/starchFileHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchHelpers.c -o $(OBJDIR)/starchHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchMetadataHelpers.c -o $(OBJDIR)/starchMetadataHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/unstarchHelpers.c -o $(OBJDIR)/unstarchHelpers.o ${INCLUDES}
-	${CXX} -x c++ -c ${BLDFLAGS} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIB3}/starchSha1Digest.c -o  ${OBJDIR}/starchSha1Digest.o ${INCLUDES}
-	${CXX} -x c++ -c ${BLDFLAGS} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIB3}/starchBase64Coding.c -o  ${OBJDIR}/starchBase64Coding.o ${INCLUDES}
+build_gprof: $(BINDIR)/gprof.$(PROG)_$(ARCH)
+
+dependencies: $(DEPENDENCIES)
+
+# Binaries
+$(BINDIR)/$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(FLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+$(BINDIR)/debug.$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(DFLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+$(BINDIR)/gprof.$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(GPROFFLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+# Object files
+$(OBJDIR)/%.o : $(LIB1)/%.cpp
+	mkdir -p $(OBJDIR) && $(CXX) -c $(BLDFLAGS) $(MACFLAGS) $< -o $@ ${INCLUDES}
+
+$(OBJDIR)/%.o : $(LIB3)/%.c
+	$(CXX) -x c++ -c $(BLDFLAGS) $(MACFLAGS) $< -o $@ ${INCLUDES}
 
 test:
 	mkdir -p $(TMPTESTDIR)

--- a/applications/bed/closestfeats/src/Makefile.darwin
+++ b/applications/bed/closestfeats/src/Makefile.darwin
@@ -21,45 +21,62 @@ LOCALBZIP2LIBDIR     = ${LOCALBZIP2DIR}
 LOCALBZIP2LIB        = ${LOCALBZIP2LIBDIR}/${LIBBZIP2}
 LOCALBZIP2INCDIR     = ${LOCALBZIP2DIR}
 LOCALZLIBDIR         = ${PARTY3}/darwin_intel_${ARCH}/zlib
-LOCALZLIBLIBDIR      = ${LOCALZLIBDIR}
-LOCALZLIBLIB         = ${LOCALZLIBLIBDIR}/${LIBZLIB}
+LOCALZLIBLIB         = ${LOCALZLIBDIR}/${LIBZLIB}
 LOCALZLIBINCDIR      = ${LOCALZLIBDIR}
+OBJDIR               = objects_$(ARCH)
 INCLUDES             = -iquote$(HEAD) -I${LOCALJANSSONINCDIR} -I${LOCALBZIP2INCDIR} -I${LOCALZLIBINCDIR}
 LIBLOCATION          = -L${LOCALJANSSONLIBDIR} -L${LOCALBZIP2LIBDIR} -L${LOCALZLIBDIR}
 LIBRARIES            = ${LOCALJANSSONLIB} ${LOCALBZIP2LIB} ${LOCALZLIBLIB}
 STDFLAGS             = -Wall -pedantic -std=c++11 -stdlib=libc++
 BLDFLAGS             = -O3 ${STDFLAGS}
 
-FLAGS                = $(BLDFLAGS) $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+DEPENDENCIES         = $(addprefix $(OBJDIR)/,   \
+                         NaN.o                   \
+												 starchBase64Coding.o    \
+												 starchConstants.o       \
+												 starchFileHelpers.o     \
+												 starchHelpers.o         \
+												 starchMetadataHelpers.o \
+												 starchSha1Digest.o      \
+												 unstarchHelpers.o       )
 
-DFLAGS               = -g -O0 ${STDFLAGS} $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+FLAGS                = $(BLDFLAGS) $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
-GPROFFLAGS           = -O -pg ${STDFLAGS} $(OBJDIR)/NaN.o $(OBJDIR)/starchConstants.o $(OBJDIR)/starchFileHelpers.o $(OBJDIR)/starchHelpers.o $(OBJDIR)/starchMetadataHelpers.o $(OBJDIR)/unstarchHelpers.o $(OBJDIR)/starchSha1Digest.o $(OBJDIR)/starchBase64Coding.o ${LIBLOCATION} ${INCLUDES}
+DFLAGS               = -g -O0 ${STDFLAGS} $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
+
+GPROFFLAGS           = -O -pg ${STDFLAGS} $(DEPENDENCIES) ${LIBLOCATION} ${INCLUDES}
 
 SOURCE1             = ClosestFeature.cpp
 BINDIR              = ../bin
 PROG                = closest-features
 
-build: dependencies
-	$(CXX) -o $(BINDIR)/$(PROG)_$(ARCH) $(FLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+MACFLAGS             = -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH)
 
-build_debug: dependencies
-	$(CXX) -o $(BINDIR)/debug.$(PROG)_$(ARCH) $(DFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+build: $(BINDIR)/$(PROG)_$(ARCH) $(DEPENDENCIES)
 
-build_gprof: dependencies
-	$(CXX) -o $(BINDIR)/gprof.$(PROG)_$(ARCH) $(FLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIBRARIES} $(SOURCE1)
+build_debug: $(BINDIR)/debug.$(PROG)_$(ARCH)
 
-dependencies:
-	rm -rf $(OBJDIR)
-	mkdir -p $(OBJDIR)
-	$(CXX) -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB1)/NaN.cpp -o $(OBJDIR)/NaN.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchConstants.c -o $(OBJDIR)/starchConstants.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchFileHelpers.c -o $(OBJDIR)/starchFileHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchHelpers.c -o $(OBJDIR)/starchHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/starchMetadataHelpers.c -o $(OBJDIR)/starchMetadataHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -c $(BLDFLAGS) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(LIB3)/unstarchHelpers.c -o $(OBJDIR)/unstarchHelpers.o ${INCLUDES}
-	${CXX} -x c++ -c ${BLDFLAGS} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIB3}/starchSha1Digest.c -o  ${OBJDIR}/starchSha1Digest.o ${INCLUDES}
-	${CXX} -x c++ -c ${BLDFLAGS} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) ${LIB3}/starchBase64Coding.c -o  ${OBJDIR}/starchBase64Coding.o ${INCLUDES}
+build_gprof: $(BINDIR)/gprof.$(PROG)_$(ARCH)
+
+dependencies: $(DEPENDENCIES)
+
+# Binaries
+$(BINDIR)/$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(FLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+$(BINDIR)/debug.$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(DFLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+$(BINDIR)/gprof.$(PROG)_$(ARCH) : $(DEPENDENCIES) $(LIBRARIES)
+	mkdir -p $(BINDIR) && $(CXX) -o $@ $(GPROFFLAGS) $(MACFLAGS) $(LIBRARIES) $(SOURCE1)
+
+# Object files
+$(OBJDIR)/%.o : $(LIB1)/%.cpp
+	mkdir -p $(OBJDIR) && $(CXX) -c $(BLDFLAGS) $(MACFLAGS) $< -o $@ ${INCLUDES}
+
+$(OBJDIR)/%.o : $(LIB3)/%.c
+	$(CXX) -x c++ -c $(BLDFLAGS) $(MACFLAGS) $< -o $@ ${INCLUDES}
+
 
 clean:
 	rm -rf $(OBJDIR)

--- a/applications/bed/conversion/src/Makefile.darwin
+++ b/applications/bed/conversion/src/Makefile.darwin
@@ -11,28 +11,31 @@ OBJDIR                    = objects
 WRAPPERDIR                = wrappers
 PROG                      = convert2bed
 SOURCE                    = convert2bed.c
+MACFLAGS                  = -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH)
 
-all: setup build
+all: build
 
-.PHONY: setup build build_debug build_gprof clean
+.PHONY: build build_debug build_gprof clean
 
-setup:
+build: $(DISTDIR)/$(PROG)_$(ARCH)
+build_debug: $(DISTDIR)/debug.$(PROG)_$(ARCH)
+build_gprof: $(DISTDIR)/gprof.$(PROG)_$(ARCH)
+
+$(DISTDIR)/$(PROG)_$(ARCH): $(PROG).c
 	mkdir -p $(DISTDIR)
-	mkdir -p $(OBJDIR)
+	$(CC) $(BLDFLAGS) $(COMMONFLAGS) $(CFLAGS) $(MACFLAGS) $(INCLUDES) $^ -o $@ $(LIBS)
 
-build: setup
-	$(CC) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(BLDFLAGS) $(COMMONFLAGS) $(CFLAGS) -c $(SOURCE) -o $(OBJDIR)/$(PROG).o $(INCLUDES)
-	$(CC) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(BLDFLAGS) $(COMMONFLAGS) $(CFLAGS) $(OBJDIR)/$(PROG).o -o $(DISTDIR)/$(PROG)_$(ARCH) $(LIBS)
+$(DISTDIR)/debug.$(PROG)_$(ARCH): $(PROG).c
+	mkdir -p $(DISTDIR)
+	$(CC) $(BLDFLAGS) $(COMMONFLAGS) $(CDFLAGS) $(MACFLAGS) $(INCLUDES) $^ -o $@ $(LIBS)
 
-build_debug: setup
-	$(CC) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(BLDFLAGS) $(COMMONFLAGS) $(CDFLAGS) -c $(SOURCE) -o $(OBJDIR)/$(PROG).o $(INCLUDES)
-	$(CC) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(BLDFLAGS) $(COMMONFLAGS) $(CDFLAGS) $(OBJDIR)/$(PROG).o -o $(DISTDIR)/debug.$(PROG)_$(ARCH) $(LIBS)
-
-build_gprof: setup
-	$(CC) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) -shared -fPIC gprof-helper.c -o gprof-helper.so $(LIBS) -ldl
-	$(CC) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(BLDFLAGS) $(COMMONFLAGS) $(CPFLAGS) -c $(SOURCE) -o $(OBJDIR)/$(PROG).o $(INCLUDES)
-	$(CC) -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) $(BLDFLAGS) $(COMMONFLAGS) $(CPFLAGS) $(OBJDIR)/$(PROG).o -o $(DISTDIR)/$(PROG)_$(ARCH) $(LIBS)
+$(DISTDIR)/gprof.$(PROG)_$(ARCH): $(PROG).c gprof-helper.so
+	mkdir -p $(DISTDIR)
+	$(CC) $(BLDFLAGS) $(COMMONFLAGS) $(CFLAGS) $(MACFLAGS) $(INCLUDES) $^ -o $@ $(LIBS)
 	@echo "\nNote: To profile convert2bed with gprof/pthreads, run:\n\t$$ LD_PRELOAD=/path/to/gprof-helper.so convert2bed"
+
+%.so: %.c
+	$(CC) $(MACFLAGS) -shared -fPIC $< -o $@ $(LIBS) -ldl
 
 clean:
 	rm -rf $(OBJDIR)

--- a/applications/bed/sort-bed/src/Makefile.darwin
+++ b/applications/bed/sort-bed/src/Makefile.darwin
@@ -9,8 +9,6 @@ DIST_DIR             = ../bin
 OBJ_DIR              = objects_${ARCH}
 OPTIMIZE             = -O3 -std=c++11 -stdlib=libc++
 WARNINGS             = -Wall
-MAIN                 = ../../../..
-HEAD                 = ${MAIN}/interfaces/general-headers
 THISDIR              = ${shell pwd}
 PARTY3               = ${THISDIR}/$(MAIN)/third-party
 LIBJANSSON           = libjansson.a
@@ -32,55 +30,54 @@ INCLUDES             = -iquote$(HEAD) -I${LOCALJANSSONINCDIR} -I${LOCALBZIP2INCD
 LIBLOCATION          = -L${LOCALJANSSONLIBDIR} -L${LOCALBZIP2LIBDIR} -L${LOCALZLIBDIR}
 LIBRARIES            = ${LOCALJANSSONLIB} ${LOCALBZIP2LIB} ${LOCALZLIBLIB}
 BLDFLAGS             = ${WARNINGS} ${OPTIMIZE}
-INCLUDES             = -iquote$(HEAD) -I${LOCALJANSSONINCDIR} -I${LOCALBZIP2INCDIR} -I${LOCALZLIBINCDIR}
-STARCHOBJS           = $(OBJ_DIR)/starchConstants.o $(OBJ_DIR)/starchFileHelpers.o $(OBJ_DIR)/starchHelpers.o $(OBJ_DIR)/starchMetadataHelpers.o $(OBJ_DIR)/unstarchHelpers.o $(OBJ_DIR)/starchSha1Digest.o $(OBJ_DIR)/starchBase64Coding.o
 
-build: sort
+build: $(DIST_DIR)/$(PROG)_$(ARCH) $(LIBRARIES)
 
-sort: sortbuild
-	${CXX} -o ${DIST_DIR}/${PROG}_${ARCH} ${BLDFLAGS} ${LIBLOCATION} ${INCLUDES} -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH) -lc++ ${STARCHOBJS} ${OBJ_DIR}/SortDetails.o ${OBJ_DIR}/Sort.o ${OBJ_DIR}/CheckSort.o ${LIBRARIES}
+build_debug: $(DIST_DIR)/debug.$(PROG)_$(ARCH)
 
-sortbuild: prep
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} ${LIB3}/starchConstants.c -o ${OBJ_DIR}/starchConstants.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} ${LIB3}/starchFileHelpers.c -o ${OBJ_DIR}/starchFileHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} ${LIB3}/starchHelpers.c -o ${OBJ_DIR}/starchHelpers.o -iquote${HEAD} ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} ${LIB3}/starchMetadataHelpers.c -o ${OBJ_DIR}/starchMetadataHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} ${LIB3}/unstarchHelpers.c -o ${OBJ_DIR}/unstarchHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} ${LIB3}/starchSha1Digest.c -o  ${OBJ_DIR}/starchSha1Digest.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} ${LIB3}/starchBase64Coding.c -o  ${OBJ_DIR}/starchBase64Coding.o ${INCLUDES}
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} SortDetails.cpp -o ${OBJ_DIR}/SortDetails.o -I${HEAD} 
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} Sort.cpp -o ${OBJ_DIR}/Sort.o -I${HEAD}
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -c ${BLDFLAGS} CheckSort.cpp -o ${OBJ_DIR}/CheckSort.o ${INCLUDES}
+build_gprof: $(DIST_DIR)/gprof.$(PROG)_$(ARCH)
 
-build_debug: prep
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c ${LIB3}/starchConstants.c -o ${OBJ_DIR}/starchConstants.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c ${LIB3}/starchFileHelpers.c -o ${OBJ_DIR}/starchFileHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c ${LIB3}/starchHelpers.c -o ${OBJ_DIR}/starchHelpers.o -iquote${HEAD} ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c ${LIB3}/starchMetadataHelpers.c -o ${OBJ_DIR}/starchMetadataHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c ${LIB3}/unstarchHelpers.c -o ${OBJ_DIR}/unstarchHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c ${LIB3}/starchSha1Digest.c -o  ${OBJ_DIR}/starchSha1Digest.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c ${LIB3}/starchBase64Coding.c -o  ${OBJ_DIR}/starchBase64Coding.o ${INCLUDES}
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c SortDetails.cpp -o ${OBJ_DIR}/SortDetails.o -I${HEAD}
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c Sort.cpp -o ${OBJ_DIR}/Sort.o -I${HEAD}
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -O0 -std=c++11 -stdlib=libc++ -c CheckSort.cpp -o ${OBJ_DIR}/CheckSort.o ${INCLUDES}
-	${CXX} -o ${DIST_DIR}/debug.${PROG}_${ARCH} ${LIBLOCATION} ${INCLUDES} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -lc++ ${STARCHOBJS} ${OBJ_DIR}/SortDetails.o ${OBJ_DIR}/Sort.o ${OBJ_DIR}/CheckSort.o ${LIBRARIES}
+dependency_names    = starchConstants starchFileHelpers starchHelpers starchMetadataHelpers unstarchHelpers starchSha1Digest starchBase64Coding SortDetails Sort CheckSort
+dependencies        = $(addprefix $(OBJ_DIR)/, $(addsuffix .o, $(dependency_names)))
+debug_dependencies    = $(addprefix $(OBJ_DIR)/debug., $(addsuffix .o, $(dependency_names)))
+gprof_dependencies    = $(addprefix $(OBJ_DIR)/gprof., $(addsuffix .o, $(dependency_names)))
 
-build_gprof: prep
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c ${LIB3}/starchConstants.c -o ${OBJ_DIR}/starchConstants.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c ${LIB3}/starchFileHelpers.c -o ${OBJ_DIR}/starchFileHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c ${LIB3}/starchHelpers.c -o ${OBJ_DIR}/starchHelpers.o -iquote${HEAD} ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c ${LIB3}/starchMetadataHelpers.c -o ${OBJ_DIR}/starchMetadataHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c ${LIB3}/unstarchHelpers.c -o ${OBJ_DIR}/unstarchHelpers.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c ${LIB3}/starchSha1Digest.c -o  ${OBJ_DIR}/starchSha1Digest.o ${INCLUDES}
-	$(CXX) -x c++ -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c ${LIB3}/starchBase64Coding.c -o  ${OBJ_DIR}/starchBase64Coding.o ${INCLUDES}
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c SortDetails.cpp -o ${OBJ_DIR}/SortDetails.o -I${HEAD}
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c Sort.cpp -o ${OBJ_DIR}/Sort.o -I${HEAD}
-	${CXX} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -pg -O -std=c++11 -stdlib=libc++ -c CheckSort.cpp -o ${OBJ_DIR}/CheckSort.o ${INCLUDES}
-	${CXX} -o ${DIST_DIR}/gprof.${PROG}_${ARCH} ${LIBLOCATION} ${INCLUDES} -mmacosx-version-min=${MIN_OSX_VERSION} -arch ${ARCH} -g -lc++ ${STARCHOBJS} ${OBJ_DIR}/SortDetails.o ${OBJ_DIR}/Sort.o ${OBJ_DIR}/CheckSort.o ${LIBRARIES}
+DBGFLAGS              = -g -O0 -std=c++11 -stdlib=libc++ $(WARNINGS)
+GPROFFLAGS            = -pg -O -std=c++11 -stdlib=libc++ $(WARNINGS)
 
-prep:
-	rm -rf ${OBJ_DIR}
-	mkdir -p ${OBJ_DIR}
+MACFLAGS = -mmacosx-version-min=$(MIN_OSX_VERSION) -arch $(ARCH)
+
+# Normal build
+$(DIST_DIR)/$(PROG)_$(ARCH) : $(dependencies) $(LIBRARIES)
+	mkdir -p $(DIST_DIR) && ${CXX} -o $@ ${BLDFLAGS} ${LIBLOCATION} ${INCLUDES} $(MACFLAGS) -lc++ $^
+
+$(OBJ_DIR)/%.o : $(LIB3)/%.c
+	mkdir -p $(OBJ_DIR) && $(CXX) -x c++ $(MACFLAGS) -c ${BLDFLAGS} $^ -o $@ ${INCLUDES}
+
+$(OBJ_DIR)/%.o : %.cpp
+	mkdir -p $(OBJ_DIR) && ${CXX} $(MACFLAGS) -c ${BLDFLAGS} $< -o $@ $(INCLUDES)
+
+
+# Debug version
+$(DIST_DIR)/debug.$(PROG)_$(ARCH) : $(debug_dependencies) $(LIBRARIES)
+	mkdir -p $(DIST_DIR) && ${CXX} -o $@ ${LIBLOCATION} ${INCLUDES} $(MACFLAGS) -g -lc++ $^
+
+$(OBJ_DIR)/debug.%.o : $(LIB3)/%.c
+	mkdir -p $(OBJ_DIR) && $(CXX) -x c++ $(MACFLAGS) -c ${DBGFLAGS} $< -o $@ ${INCLUDES}
+
+$(OBJ_DIR)/debug.%.o : %.cpp
+	mkdir -p $(OBJ_DIR) && ${CXX} $(MACFLAGS) -c ${DBGFLAGS} $< -o $@ $(INCLUDES)
+
+
+# For profiling
+$(DIST_DIR)/gprof.$(PROG)_$(ARCH) : $(gprof_dependencies) $(LIBRARIES)
+	mkdir -p $(DIST_DIR) && ${CXX} -o $@ ${LIBLOCATION} ${INCLUDES} $(MACFLAGS) -g -lc++ $^
+
+$(OBJ_DIR)/gprof.%.o : $(LIB3)/%.c
+	mkdir -p $(OBJ_DIR) && $(CXX) -x c++ $(MACFLAGS) -c ${GPROFFLAGS} $< -o $@ ${INCLUDES}
+
+$(OBJ_DIR)/gprof.%.o : %.cpp
+	mkdir -p $(OBJ_DIR) && ${CXX} $(MACFLAGS) -c ${GPROFFLAGS} $< -o $@ $(INCLUDES)
 
 clean:
 	rm -rf ${OBJ_DIR}*

--- a/applications/bed/starch/src/Makefile.darwin
+++ b/applications/bed/starch/src/Makefile.darwin
@@ -43,66 +43,62 @@ CDFLAGS                   = -D__STDC_CONSTANT_MACROS -D_FILE_OFFSET_BITS=64 -D_L
 CXXDFLAGS                 = -D__STDC_CONSTANT_MACROS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE=1 -DUSE_ZLIB -DUSE_BZLIB -O0 -g ${WARNINGS} -std=c++11 -stdlib=libc++ -DDEBUG_VERBOSE=1 -mmacosx-version-min=$(MIN_OSX_VERSION) -arch ${ARCH}
 
 
-build: dependencies starchLibrary starch unstarch starchcat starchcluster
-	rm -f *~
+DEPENDENCY_NAMES          = starchFileHelpers.o starchHelpers.o starchMetadataHelpers.o starchSha1Digest.o unstarchHelpers.o starchConstants.o starchBase64Coding.o
+DEPENDENCIES              = $(addprefix $(LOCALOBJDIR)/, $(DEPENDENCY_NAMES))
+DEBUG_DEPENDENCIES        = $(addprefix $(LOCALOBJDIR)/debug., $(DEPENDENCY_NAMES))
 
-# dependencies-related recipes all have mkdirs prereqs
-#   and pretty much everything else has dependencies-related prereqs at some level
-#   -> let make figure out hierarchy and eliminate mkdir/rm race conditions
-dependencies: mkdirs
-	${CC} ${CFLAGS} -c ${OBJDIR}/starchConstants.c -o ${LOCALOBJDIR}/starchConstants.o ${INCLUDES}
-	${CC} ${CFLAGS} -c ${OBJDIR}/starchMetadataHelpers.c -o  ${LOCALOBJDIR}/starchMetadataHelpers.o ${INCLUDES}
-	${CC} ${CFLAGS} -c ${OBJDIR}/unstarchHelpers.c -o  ${LOCALOBJDIR}/unstarchHelpers.o ${INCLUDES}
-	${CC} ${CFLAGS} -c ${OBJDIR}/starchHelpers.c -o  ${LOCALOBJDIR}/starchHelpers.o ${INCLUDES}
-	${CC} ${CFLAGS} -c ${OBJDIR}/starchFileHelpers.c -o  ${LOCALOBJDIR}/starchFileHelpers.o ${INCLUDES}
-	${CC} ${CFLAGS} -c ${OBJDIR}/starchSha1Digest.c -o  ${LOCALOBJDIR}/starchSha1Digest.o ${INCLUDES}
-	${CC} ${CFLAGS} -c ${OBJDIR}/starchBase64Coding.c -o  ${LOCALOBJDIR}/starchBase64Coding.o ${INCLUDES}
+starch: $(BINDIR)/starch
+unstarch: $(BINDIR)/unstarch
+starchcat: $(BINDIR)/unstarch
+starch_debug: $(BINDIR)/debug.starch
+unstarch_debug: $(BINDIR)/debug.unstarch
+starchcat_debug: $(BINDIR)/debug.starchcat
+
+build: dependencies starchLibrary $(BINDIR)/starch $(BINDIR)/unstarch $(BINDIR)/starchcat starchcluster
+	rm -f *~
 
 build_debug: dependencies_debug starch_debug unstarch_debug starchcat_debug
 	rm -f *~
 
-dependencies_debug: mkdirs
-	${CC} ${CDFLAGS} -c ${OBJDIR}/starchConstants.c -o ${LOCALOBJDIR}/starchConstants.o ${INCLUDES}
-	${CC} ${CDFLAGS} -c ${OBJDIR}/unstarchHelpers.c -o  ${LOCALOBJDIR}/unstarchHelpers.o ${INCLUDES}
-	${CC} ${CDFLAGS} -c ${OBJDIR}/starchHelpers.c -o  ${LOCALOBJDIR}/starchHelpers.o ${INCLUDES}
-	${CC} ${CDFLAGS} -c ${OBJDIR}/starchMetadataHelpers.c -o  ${LOCALOBJDIR}/starchMetadataHelpers.o ${INCLUDES}
-	${CC} ${CDFLAGS} -c ${OBJDIR}/starchFileHelpers.c -o  ${LOCALOBJDIR}/starchFileHelpers.o ${INCLUDES}
-	${CC} ${CDFLAGS} -c ${OBJDIR}/starchSha1Digest.c -o  ${LOCALOBJDIR}/starchSha1Digest.o ${INCLUDES}
-	${CC} ${CDFLAGS} -c ${OBJDIR}/starchBase64Coding.c -o  ${LOCALOBJDIR}/starchBase64Coding.o ${INCLUDES}
+dependencies: mkdirs $(DEPENDENCIES)
 
-starchLibrary: dependencies
-	${AR} rcs ${LOCALSTARCHLIB} ${LOCALOBJDIR}/starchConstants.o  ${LOCALOBJDIR}/unstarchHelpers.o  ${LOCALOBJDIR}/starchHelpers.o  ${LOCALOBJDIR}/starchMetadataHelpers.o  ${LOCALOBJDIR}/starchFileHelpers.o ${LOCALOBJDIR}/starchSha1Digest.o ${LOCALOBJDIR}/starchBase64Coding.o
+dependencies_debug: mkdirs $(DEBUG_DEPENDENCIES)
 
-starchLibrary_debug: dependencies_debug
-	${AR} rcs ${LOCALSTARCHLIBDEBUG} ${LOCALOBJDIR}/starchConstants.o  ${LOCALOBJDIR}/unstarchHelpers.o  ${LOCALOBJDIR}/starchHelpers.o  ${LOCALOBJDIR}/starchMetadataHelpers.o  ${LOCALOBJDIR}/starchFileHelpers.o ${LOCALOBJDIR}/starchSha1Digest.o ${LOCALOBJDIR}/starchBase64Coding.o
+# Dependency building
+$(LOCALOBJDIR)/%.o : $(OBJDIR)/%.c
+	$(CC) $(CFLAGS) -c $< -o $@ $(INCLUDES)
 
-starch: starchLibrary
-	${CC} ${CFLAGS} -c starch.c -o $(LOCALOBJDIR)/starch.o ${INCLUDES}
-	${CXX} ${CXXFLAGS} -lc++ $(LOCALOBJDIR)/starch.o -o ${BINDIR}/starch ${LOCALSTARCHLIB} ${LIBRARIES}
+$(LOCALOBJDIR)/debug.%.o : $(OBJDIR)/%.c
+	$(CC) $(CDFLAGS) -c $< -o $@ $(INCLUDES)
 
-starch_debug: starchLibrary_debug
-	${CC} ${CDFLAGS} -c starch.c -o $(LOCALOBJDIR)/debug.starch.o ${INCLUDES}
-	${CXX} ${CXXDFLAGS} -lc++ $(LOCALOBJDIR)/debug.starch.o -o ${BINDIR}/debug.starch ${LOCALSTARCHLIBDEBUG} ${LIBRARIES}
+$(LOCALOBJDIR)/%.o : %.c $(LOCALSTARCHLIB)
+	$(CC) $(CFLAGS) -c $< -o $@ $(INCLUDES)
 
-unstarch: starchLibrary
-	${CC} ${CFLAGS} -c unstarch.c -o $(LOCALOBJDIR)/unstarch.o ${INCLUDES}
-	${CXX} ${CXXFLAGS} -lc++ $(LOCALOBJDIR)/unstarch.o -o ${BINDIR}/unstarch ${LOCALSTARCHLIB} ${LIBRARIES}
+$(LOCALOBJDIR)/debug.%.o : %.c $(LOCALSTARCHLIBDEBUG)
+	$(CC) $(CDFLAGS) -c $< -o $@ $(INCLUDES)
 
-unstarch_debug: starchLibrary_debug
-	${CC} ${CDFLAGS} -c unstarch.c -o $(LOCALOBJDIR)/debug.unstarch.o ${INCLUDES}
-	${CXX} ${CXXDFLAGS} -lc++ $(LOCALOBJDIR)/debug.unstarch.o -o ${BINDIR}/debug.unstarch ${LOCALSTARCHLIBDEBUG} ${LIBRARIES}
+# Bin building
+#
+$(BINDIR)/% : $(LOCALOBJDIR)/%.o $(LOCALSTARCHLIB)
+	$(CXX) $(CXXFLAGS) -lc++ $< -o $@ $(LOCALSTARCHLIB) $(LIBRARIES)
 
-starchcluster: starchcat
+$(BINDIR)/debug.% : $(LOCALOBJDIR)/%.o $(LOCALSTARCHLIB)
+	$(CXX) $(CXXDFLAGS) -lc++ $< -o $@ $(LOCALSTARCHLIB) $(LIBRARIES)
+
+starchcluster: $(BINDIR)/starchcat
 	cp starchcluster_sge.tcsh ${BINDIR}/starchcluster_sge
 	cp starchcluster_gnuParallel.tcsh ${BINDIR}/starchcluster_gnuParallel
 
-starchcat: starchLibrary
-	${CC} ${CFLAGS} -c starchcat.c -o $(LOCALOBJDIR)/starchcat.o ${INCLUDES}
-	${CXX} ${CXXFLAGS} -lc++ $(LOCALOBJDIR)/starchcat.o -o ${BINDIR}/starchcat ${LOCALSTARCHLIB} ${LIBRARIES}
+# Libraries
+starchLibrary: $(LOCALSTARCHLIB)
 
-starchcat_debug: starchLibrary_debug
-	${CC} ${CDFLAGS} -c starchcat.c -o $(LOCALOBJDIR)/starchcat.o ${INCLUDES}
-	${CXX} ${CXXDFLAGS} -lc++ $(LOCALOBJDIR)/starchcat.o -o ${BINDIR}/debug.starchcat ${LOCALSTARCHLIBDEBUG} ${LIBRARIES}
+$(LOCALSTARCHLIB): $(DEPENDENCIES)
+	${AR} rcs $@ $^
+
+starchLibrary_debug: $(LOCALSTARCHLIBDEBUG)
+
+$(LOCALSTARCHLIBDEBUG) : $(DEBUG_DEPENDENCIES)
+	${AR} rcs $@ $<
 
 test: starch unstarch starchcat
 	cp ${BINDIR}/starch ${TEST_OSX_BINDIR}/starch

--- a/system.mk/Makefile.darwin
+++ b/system.mk/Makefile.darwin
@@ -196,37 +196,51 @@ mkdirs:
 #
 # third-party libraries
 #
-support_intel_i386: jansson_support_intel_i386_c bzip2_support_intel_i386_c zlib_support_intel_i386_c
 
-support_intel_x86_64: jansson_support_intel_x86_64_c bzip2_support_intel_x86_64_c zlib_support_intel_x86_64_c
+JANNSON_LIB=jansson/lib/libjansson.a
+BZIP_LIB=bzip2/libbz2.a
+ZLIB_LIB=zlib/libz.a
+
+386_LIBS=$(addprefix $(PARTY3)/$(I386)/, $(JANNSON_LIB) $(BZIP_LIB) $(ZLIB_LIB))
+x64_LIBS=$(addprefix $(PARTY3)/$(X86_64)/, $(JANNSON_LIB) $(BZIP_LIB) $(ZLIB_LIB))
+
+support_intel_i386: $(386_LIBS)
+
+support_intel_x86_64: $(x64_LIBS)
 
 support_intel: support_intel_i386 support_intel_x86_64
 
 support: | mkdirs
 	$(MAKE) support_intel -f $(SELF)
 
-jansson_support_intel_i386_c:
-	bzcat ${WHICHJANSSON}.tar.bz2 | tar -x -C ${PARTY3}/$(I386)/
+$(PARTY3)/$(I386)/$(JANNSON_LIB): $(WHICHJANSSON).tar.bz2
+	rm -rf $(PARTY3)/$(I386)/$(JANSSONVERSION)
+	bzcat $< | tar -x -C ${PARTY3}/$(I386)/
 	cd ${PARTY3}/$(I386)/${JANSSONVERSION} && export MACOSX_DEPLOYMENT_TARGET=10.7 && export ARCH=i386 && export CC=${CC} && export CXX=${CXX} && ./configure --prefix=${WDIR}/${PARTY3}/$(I386)/${JANSSONVERSION} CFLAGS="-arch i386" --build="i386" && $(MAKE) && $(MAKE) install && cd ../ && rm -f jansson && ln -sf ${JANSSONVERSION} jansson && cd ${WDIR}
 
-jansson_support_intel_x86_64_c:
-	bzcat ${WHICHJANSSON}.tar.bz2 | tar -x -C ${PARTY3}/$(X86_64)/
+$(PARTY3)/$(X86_64)/$(JANNSON_LIB): ${WHICHJANSSON}.tar.bz2
+	rm -rf $(PARTY3)/$(X86_64)/$(JANSSONVERSION)
+	bzcat $< | tar -x -C ${PARTY3}/$(X86_64)/
 	cd ${PARTY3}/$(X86_64)/${JANSSONVERSION} && export MACOSX_DEPLOYMENT_TARGET=10.7 && export ARCH=x86_64 && export CC=${CC} && export CXX=${CXX} && ./configure --prefix=${WDIR}/${PARTY3}/$(X86_64)/${JANSSONVERSION} CFLAGS="-arch x86_64" --build="x86_64" && $(MAKE) && $(MAKE) install && cd ../ && rm -f jansson && ln -sf ${JANSSONVERSION} jansson && cd ${WDIR}
 
-bzip2_support_intel_i386_c:
-	bzcat ${WHICHBZIP2}.tar.bz2 | tar -x -C ${PARTY3}/$(I386)/
+$(PARTY3)/$(I386)/$(BZIP_LIB): ${WHICHBZIP2}.tar.bz2
+	-rm -rf $(PARTY3)/$(I386)/$(BZIP2VERSION)
+	bzcat $< | tar -x -C ${PARTY3}/$(I386)/
 	cd ${PARTY3}/$(I386)/${BZIP2VERSION} && export MACOSX_DEPLOYMENT_TARGET=10.7 && export ARCH=i386 && export CC=${CC} && export CXX=${CXX} && $(MAKE) -f Makefile.darwin_i386 libbz2.a && cd ../ && rm -f bzip2 && ln -sf ${BZIP2VERSION} bzip2 && cd ${WDIR}
 
-bzip2_support_intel_x86_64_c:
-	bzcat ${WHICHBZIP2}.tar.bz2 | tar -x -C ${PARTY3}/$(X86_64)/
+$(PARTY3)/$(X86_64)/$(BZIP_LIB): ${WHICHBZIP2}.tar.bz2
+	-rm -rf $(PARTY3)/$(X86_64)/$(BZIP2VERSION)
+	bzcat $< | tar -x -C ${PARTY3}/$(X86_64)/
 	cd ${PARTY3}/$(X86_64)/${BZIP2VERSION} && export MACOSX_DEPLOYMENT_TARGET=10.7 && export ARCH=x86_64 && export CC=${CC} && export CXX=${CXX} && $(MAKE) -f Makefile.darwin_x86_64 libbz2.a && cd ../ && rm -f bzip2 && ln -sf ${BZIP2VERSION} bzip2 && cd ${WDIR}
 
-zlib_support_intel_i386_c:
-	bzcat ${WHICHZLIB}.tar.bz2 | tar -x -C ${PARTY3}/$(I386)/
+$(PARTY3)/$(I386)/$(ZLIB_LIB): ${WHICHZLIB}.tar.bz2
+	-rm -rf $(PARTY3)/$(I386)/$(ZLIBVERSION)
+	bzcat $< | tar -x -C ${PARTY3}/$(I386)/
 	cd ${PARTY3}/$(I386)/${ZLIBVERSION} && export MACOSX_DEPLOYMENT_TARGET=10.7 && export ARCH=i386 && export CC=${CC} && export CXX=${CXX} && ./configure --static --archs="-arch i386" && $(MAKE) && cd ../ && rm -f zlib && ln -sf ${ZLIBVERSION} zlib && cd ${WDIR}
 
-zlib_support_intel_x86_64_c:
-	bzcat ${WHICHZLIB}.tar.bz2 | tar -x -C ${PARTY3}/$(X86_64)/
+$(PARTY3)/$(X86_64)/$(ZLIB_LIB): ${WHICHZLIB}.tar.bz2
+	-rm -rf $(PARTY3)/$(X86_64)/$(ZLIBVERSION)
+	bzcat $< | tar -x -C ${PARTY3}/$(X86_64)/
 	cd ${PARTY3}/$(X86_64)/${ZLIBVERSION} && export MACOSX_DEPLOYMENT_TARGET=10.7 && export ARCH=x86_64 && export CC=${CC} && export CXX=${CXX} && ./configure --static --archs="-arch x86_64" && $(MAKE) && cd ../ && rm -f zlib && ln -sf ${ZLIBVERSION} zlib && cd ${WDIR}
 
 


### PR DESCRIPTION
⚠️ Not yet ready to merge - hasn't been tested enough yet. ⚠️ 

This avoids redoing unnecessary build operations - after the initial `make`, subsequent invocations should be much faster.

Also planning on incorporating @alexpreynolds's suggestions about (by default) only building the binary appropriate to the user's architecture, rather than the fat binaries.