### PR TITLE
fix for bedmap --header produces no output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ applications/bed/closestfeats/bin/
 applications/bed/conversion/bin/
 applications/bed/sort-bed/bin/
 applications/bed/starch/bin/
+
+.vscode

--- a/interfaces/general-headers/data/starch/starchApi.hpp
+++ b/interfaces/general-headers/data/starch/starchApi.hpp
@@ -1519,6 +1519,11 @@ namespace starch
                 case kBzip2: {
                     // extract untransformed line from archive
                     UNSTARCH_bzReadLine(bzFp, &bzOutput);
+                    if (bzOutput && * bzOutput == '#')
+                    {
+                        UNSTARCH_bzReadLine(bzFp, &bzOutput);
+                    }
+
                     if (bzOutput) {
 #ifdef DEBUG
                         std::fprintf(stderr, "--> bzOutput [ %s ]\n", bzOutput);
@@ -1583,7 +1588,6 @@ namespace starch
                                     break;
                             } while (res != 0);
                         }
-
                         // if the first character of the first untransformed token is 'p', then
                         // we have not yet extracted a BED line, and so we call extractLine()
                         // once again to get BED output
@@ -1648,6 +1652,11 @@ namespace starch
 #ifdef DEBUG
                         std::fprintf(stderr, "--> needed to read a new chunk because we're in the middle of an incomplete line\n");
 #endif
+                        zReadLine();
+                    }
+
+                    if (zHave >= zOutBufIdx && !postBreakdownZValuesIdentical && * zLineBuf == '#')
+                    {
                         zReadLine();
                     }
 

--- a/interfaces/general-headers/data/starch/starchApi.hpp
+++ b/interfaces/general-headers/data/starch/starchApi.hpp
@@ -727,6 +727,13 @@ namespace starch
         bool                            getAllChromosomesHaveDuplicateElement() { Metadata *_archMdIter; for (_archMdIter = archMd; _archMdIter != NULL; _archMdIter = _archMdIter->next) { if (UNSTARCH_duplicateElementExistsForChromosome(archMd, _archMdIter->chromosome) == kStarchTrue) return true; } return false; }
         bool                            getAllChromosomesHaveNestedElement() { Metadata *_archMdIter; for (_archMdIter = archMd; _archMdIter != NULL; _archMdIter = _archMdIter->next) { if (UNSTARCH_nestedElementExistsForChromosome(archMd, _archMdIter->chromosome) == kStarchTrue) return true; } return false; }
         inline bool                     isEOF() { return (!getCurrentChromosome()); }
+        inline bool isSpecialLine(const char* buf) {
+            return (std::strncmp(buf, kStarchBedHeaderTrack, strlen(kStarchBedHeaderTrack)) == 0 ||
+                    std::strncmp(buf, kStarchBedHeaderBrowser, strlen(kStarchBedHeaderBrowser)) == 0 ||
+                    std::strncmp(buf, kStarchBedHeaderSAM, strlen(kStarchBedHeaderSAM)) == 0 ||
+                    std::strncmp(buf, kStarchBedHeaderVCF, strlen(kStarchBedHeaderVCF)) == 0 ||
+                    std::strncmp(buf, kStarchBedGenericComment, strlen(kStarchBedGenericComment)) == 0);
+        }
 
         // ------------        
 
@@ -1519,7 +1526,7 @@ namespace starch
                 case kBzip2: {
                     // extract untransformed line from archive
                     UNSTARCH_bzReadLine(bzFp, &bzOutput);
-                    if (bzOutput && * bzOutput == '#')
+                    while (bzOutput && isSpecialLine(reinterpret_cast<char *>(bzOutput)))
                     {
                         UNSTARCH_bzReadLine(bzFp, &bzOutput);
                     }
@@ -1655,7 +1662,7 @@ namespace starch
                         zReadLine();
                     }
 
-                    if (zHave >= zOutBufIdx && !postBreakdownZValuesIdentical && * zLineBuf == '#')
+                    while (zHave >= zOutBufIdx && !postBreakdownZValuesIdentical && isSpecialLine(zLineBuf))
                     {
                         zReadLine();
                     }


### PR DESCRIPTION
Hi,

I was looking into issue #220 and I think that when bedmap (and other bedops tools) is reading `.starch` files with a header, he tries to parse the header as values and fails to return any result. To avoid this, I've included a hotfix on `starchApi.hpp` to the `extractLine` function which checks if the current line matches any of the headers and skips until it doesn't.

I've implemented this change and the example from #220 (as well as other tests) and worked fine.

```
# bash bedops_header_test.sh
bedops
  citation: http://bioinformatics.oxfordjournals.org/content/28/14/1919.abstract
            https://doi.org/10.1093/bioinformatics/bts277
  version:  2.4.36 (typical)
  authors:  Shane Neph & Scott Kuehn

Header starch contents:
#chrom	chromStart	chromEnd	rsid
chr1	1121013	1121014	rs3813204
chr1	1121340	1121341	rs4297230
chr1	1121793	1121794	rs11260549
chr1	1122023	1122024	rs4314833

No header starch contents:
chr1	1121013	1121014	rs3813204
chr1	1121340	1121341	rs4297230
chr1	1121793	1121794	rs11260549
chr1	1122023	1122024	rs4314833

First run:
chr1	1121013	1121014	rs3813204|chr1	1121013	1121014	rs3813204
chr1	1121340	1121341	rs4297230|chr1	1121340	1121341	rs4297230
chr1	1121793	1121794	rs11260549|chr1	1121793	1121794	rs11260549
chr1	1122023	1122024	rs4314833|chr1	1122023	1122024	rs4314833

Second run:
chr1	1121013	1121014	rs3813204|chr1	1121013	1121014	rs3813204
chr1	1121340	1121341	rs4297230|chr1	1121340	1121341	rs4297230
chr1	1121793	1121794	rs11260549|chr1	1121793	1121794	rs11260549
chr1	1122023	1122024	rs4314833|chr1	1122023	1122024	rs4314833
```

I've also run the bedops tests and only `--ec` failed (which was already failing on my machine).

I hope this helps